### PR TITLE
Fix reporting missing executable.

### DIFF
--- a/nutmeg/processor.py
+++ b/nutmeg/processor.py
@@ -78,8 +78,8 @@ class Proc():
         """
         self.fname_exe = find_executable(fname_exe)
 
-        if not os.path.isfile(self.fname_exe):
-            raise ValueError('Executable not found: {}'.format(self.fname_exe))
+        if self.fname_exe == None or not os.path.isfile(self.fname_exe):
+            raise ValueError('Executable not found: {}'.format(fname_exe))
 
         # if not path_work:
         #     path_work = os.path.curdir


### PR DESCRIPTION
find_executable() returns None if it could not find an executable, running None through os.path.isfile() throws an error that your code cannot catch.
For your code to catch that case, you need to check if it is null.  Also need to report the original fname since self.fname was rewritten as None.